### PR TITLE
chore: update Go to 1.25 and Hugo to 0.151.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  HUGO_VERSION: v0.150.1
+  HUGO_VERSION: v0.151.0
 
 jobs:
   test:
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Cache Go modules and Hugo binary
         id: cache-hugo
@@ -130,7 +130,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Cache Go modules and Hugo binary
         id: cache-hugo

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/LeakIX/hugo-leakix-dark
 
-go 1.24
+go 1.25

--- a/leakix-dark/theme.toml
+++ b/leakix-dark/theme.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/LeakIX/leakix-dark-theme"
 demo = "https://leakix.github.io/leakix-dark-theme/"
 tags = ["blog", "dark", "responsive", "bootstrap", "search", "modern", "customizable", "monospace"]
 features = ["responsive", "dark mode", "search", "syntax highlighting", "SEO optimized", "social sharing", "customizable branding"]
-min_version = "0.120.0"
+min_version = "0.151.0"
 
 [author]
   name = "LeakIX Team"

--- a/scripts/cancel-long-runs.sh
+++ b/scripts/cancel-long-runs.sh
@@ -21,7 +21,7 @@ echo "$long_runs" | while read -r run_id; do
         title=$(echo "$run_info" | jq -r '.displayTitle')
         created=$(echo "$run_info" | jq -r '.createdAt')
         event=$(echo "$run_info" | jq -r '.event')
-        
+
         echo "Cancelling run $run_id: '$title' (event: $event, created: $created)"
         gh run cancel "$run_id"
     fi


### PR DESCRIPTION
Update Go version to 1.25 in go.mod and CI workflows. Update Hugo minimum version to 0.151.0 in theme.toml and CI workflows.